### PR TITLE
update links to 6.2

### DIFF
--- a/landing-page/documentation.html
+++ b/landing-page/documentation.html
@@ -51,7 +51,7 @@
           <div class="row clearfix">
             <div class="col-md-3 column">
               <h3>
-                <a href="http://docs.openmm.org/6.1.0/userguide/index.html">User Guide</a>
+                <a href="http://docs.openmm.org/6.2.0/userguide/index.html">User Guide</a>
               </h3>
               <p class="enlarge">
                 Start here if it's your first time using OpenMM. These documents will get you up and running simulations in short order. 
@@ -59,7 +59,7 @@
             </div>
             <div class="col-md-3 column">
               <h3>
-                <a href="http://docs.openmm.org/6.1.0/developerguide/index.html">Dev Guide</a>
+                <a href="http://docs.openmm.org/6.2.0/developerguide/index.html">Dev Guide</a>
               </h3>
               <p class="enlarge">
                 This section provides in-depth information on the code-base and how to contribute to the development of OpenMM itself.
@@ -67,7 +67,7 @@
             </div>
             <div class="col-md-3 column">
               <h3>
-                <a href="http://docs.openmm.org/6.1.0/api-python/annotated.html">Python API
+                <a href="http://docs.openmm.org/6.2.0/api-python/annotated.html">Python API
                 </a>
               </h3>
               <p class="enlarge">
@@ -76,7 +76,7 @@
             </div>
             <div class="col-md-3 column">
               <h3>
-                <a href="http://docs.openmm.org/6.1.0/api-c++/namespaceOpenMM.html">C++ API
+                <a href="http://docs.openmm.org/6.2.0/api-c++/namespaceOpenMM.html">C++ API
                 </a>
               </h3>
               <p class="enlarge">


### PR DESCRIPTION
@peastman: I pushed the 6.2.0 docs already. This updates the links
- http://docs.openmm.org/6.2.0/userguide/index.html
- http://docs.openmm.org/6.2.0/developerguide/index.html
- http://docs.openmm.org/6.2.0/api-python/annotated.html
- http://docs.openmm.org/6.2.0/api-c++/namespaceOpenMM.html
