### PR TITLE
Update links do documentation to use `latest` instead of `7.1.0`

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -24,7 +24,7 @@ title: OpenMM Documentation
         <div class="row clearfix">
           <div class="col-md-3 column">
             <h3>
-              <a href="http://docs.openmm.org/7.1.0/userguide/index.html">User Guide</a>
+              <a href="http://docs.openmm.org/latest/userguide/index.html">User Guide</a>
             </h3>
             <p class="enlarge">
               Start here if it's your first time using OpenMM. These documents will get you up and running simulations in short order.
@@ -32,7 +32,7 @@ title: OpenMM Documentation
           </div>
           <div class="col-md-3 column">
             <h3>
-              <a href="http://docs.openmm.org/7.1.0/developerguide/index.html">Dev Guide</a>
+              <a href="http://docs.openmm.org/latest/developerguide/index.html">Dev Guide</a>
             </h3>
             <p class="enlarge">
               This section provides in-depth information on the code-base and how to contribute to the development of OpenMM itself.
@@ -40,7 +40,7 @@ title: OpenMM Documentation
           </div>
           <div class="col-md-3 column">
             <h3>
-              <a href="http://docs.openmm.org/7.1.0/api-python/index.html">Python API
+              <a href="http://docs.openmm.org/latest/api-python/index.html">Python API
               </a>
             </h3>
             <p class="enlarge">
@@ -49,7 +49,7 @@ title: OpenMM Documentation
           </div>
           <div class="col-md-3 column">
             <h3>
-              <a href="http://docs.openmm.org/7.1.0/api-c++/index.html">C++ API
+              <a href="http://docs.openmm.org/latest/api-c++/index.html">C++ API
               </a>
             </h3>
             <p class="enlarge">


### PR DESCRIPTION
The preview from #22 is now online here:

http://openmm.org/preview/documentation.html

The links to the docs now go to `latest` instead of `7.1.0`.

This looks like it works, so it should be good to merge into `master` to make it live.